### PR TITLE
Set the Authorization header via setAxiosHeaders() in uploadWyreDocument()

### DIFF
--- a/src/services/wyreApiService.js
+++ b/src/services/wyreApiService.js
@@ -93,8 +93,7 @@ export async function uploadWyreDocument(file, fieldId, accountId) {
   await instance.post("/v3/accounts/" + accountId + "/" + fieldId, file, {
     baseURL: wyreApi.testWyreApiUrl,
     headers: {
-      "Content-Type": file.type,
-      Authorization: "Bearer " + localStorage.getItem(SECRET_KEY)
+      "Content-Type": file.type
     }
   });
 }

--- a/src/services/wyreApiService.js
+++ b/src/services/wyreApiService.js
@@ -89,6 +89,7 @@ export async function updateWyrePersonalDetailsAccount(
 
 export async function uploadWyreDocument(file, fieldId, accountId) {
   console.log("Uploading document: " + fieldId);
+  setAxiosHeaders();
   await instance.post("/v3/accounts/" + accountId + "/" + fieldId, file, {
     baseURL: wyreApi.testWyreApiUrl,
     headers: {


### PR DESCRIPTION
This probably only worked before because there was at least one different request enforcing that the Authorization header was set. While it may continue working for all intended use cases, it makes using this method as a reference more difficult.